### PR TITLE
Fix memory page route

### DIFF
--- a/enhanced_csp/main.py
+++ b/enhanced_csp/main.py
@@ -1300,6 +1300,12 @@ async def performance_page():
     """Performance monitoring"""
     return serve_html_page("performance", "⚡ Performance Monitor")
 
+# Memory Management Page
+@app.get("/memory", response_class=HTMLResponse)
+async def memory_page():
+    """Memory management dashboard"""
+    return serve_html_page("memory", "🧠 Memory Management")
+
 # Security and Management Pages
 @app.get("/security", response_class=HTMLResponse)
 async def security_page():


### PR DESCRIPTION
## Summary
- expose /memory page in main FastAPI app

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_6858d5edadac832893fba9df5b836105