### PR TITLE
Add Zustand store

### DIFF
--- a/enhanced_csp/frontend/package.json
+++ b/enhanced_csp/frontend/package.json
@@ -9,7 +9,8 @@
     "test": "echo \"No tests yet\" && exit 0"
   },
   "dependencies": {
-    "@azure/msal-browser": "^2.38.3"
+    "@azure/msal-browser": "^2.38.3",
+    "zustand": "^4.5.2"
   },
   "devDependencies": {
     "live-server": "^1.2.2"

--- a/enhanced_csp/frontend/pages/Dashboard.js
+++ b/enhanced_csp/frontend/pages/Dashboard.js
@@ -4,14 +4,16 @@
  */
 
 import React from 'react';
-import { Container, Row, Col, Card, Badge } from 'react-bootstrap';
+import { Container, Row, Col, Card, Badge, Form } from 'react-bootstrap';
 import { Activity, Users, Shield, Cpu } from 'lucide-react';
 
 import { useUserProfile } from '../hooks/useUserProfile';
 import RoleGuard from '../components/RoleGuard';
+import { useAppStore } from '../stores/appStore';
 
 const Dashboard = () => {
     const { userProfile, loading } = useUserProfile();
+    const { darkMode, toggleDarkMode } = useAppStore();
 
     if (loading) {
         return (
@@ -22,14 +24,23 @@ const Dashboard = () => {
     }
 
     return (
-        <Container className="mt-4">
+        <Container className={`mt-4 ${darkMode ? 'bg-dark text-white' : ''}`}>
             <Row>
                 <Col>
                     <h2>Welcome to Enhanced CSP System</h2>
                     <p className="text-muted">
-                        Hello, {userProfile?.displayName || 'User'}! 
+                        Hello, {userProfile?.displayName || 'User'}!
                         Your role: <Badge bg="primary">{userProfile?.roles?.[0] || 'User'}</Badge>
                     </p>
+                </Col>
+                <Col className="text-end" md="auto">
+                    <Form.Check
+                        type="switch"
+                        id="dark-mode-toggle"
+                        label="Dark Mode"
+                        checked={darkMode}
+                        onChange={toggleDarkMode}
+                    />
                 </Col>
             </Row>
 

--- a/enhanced_csp/frontend/stores/appStore.js
+++ b/enhanced_csp/frontend/stores/appStore.js
@@ -1,0 +1,7 @@
+import { create } from 'zustand'
+
+export const useAppStore = create((set) => ({
+  darkMode: false,
+  toggleDarkMode: () => set((state) => ({ darkMode: !state.darkMode })),
+  setDarkMode: (value) => set({ darkMode: value })
+}))


### PR DESCRIPTION
## Summary
- add Zustand store for frontend global state
- update Dashboard page to toggle dark mode via Zustand
- register zustand dependency

## Testing
- `npm test`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*


------
https://chatgpt.com/codex/tasks/task_e_685a597b41248328be30806ae33dbcb2