### PR TITLE
Remove auth-protection.js links

### DIFF
--- a/enhanced_csp/frontend/pages/admin.html
+++ b/enhanced_csp/frontend/pages/admin.html
@@ -716,7 +716,6 @@
     </style>
 </head>
     <!-- CSP Local Authentication Protection -->
-    <script src="../js/auth-protection.js"></script>
     <style>
         /* Authentication header styles */
         #csp-auth-header {

--- a/enhanced_csp/frontend/pages/ai-agents.html
+++ b/enhanced_csp/frontend/pages/ai-agents.html
@@ -506,7 +506,6 @@
     </style>
 </head>
     <!-- CSP Local Authentication Protection -->
-    <script src="../js/auth-protection.js"></script>
     <style>
         /* Authentication header styles */
         #csp-auth-header {

--- a/enhanced_csp/frontend/pages/csp_admin_portal.html
+++ b/enhanced_csp/frontend/pages/csp_admin_portal.html
@@ -601,7 +601,6 @@
     </style>
 </head>
     <!-- CSP Local Authentication Protection -->
-    <script src="../js/auth-protection.js"></script>
     <style>
         /* Authentication header styles */
         #csp-auth-header {

--- a/enhanced_csp/frontend/pages/designer.html
+++ b/enhanced_csp/frontend/pages/designer.html
@@ -750,7 +750,6 @@
     </style>
 </head>
     <!-- CSP Local Authentication Protection -->
-    <script src="../js/auth-protection.js"></script>
     <style>
         /* Authentication header styles */
         #csp-auth-header {

--- a/enhanced_csp/frontend/pages/developer_tools.html
+++ b/enhanced_csp/frontend/pages/developer_tools.html
@@ -426,7 +426,6 @@
     </style>
 </head>
     <!-- CSP Local Authentication Protection -->
-    <script src="../js/auth-protection.js"></script>
     <style>
         /* Authentication header styles */
         #csp-auth-header {

--- a/enhanced_csp/frontend/pages/index.html
+++ b/enhanced_csp/frontend/pages/index.html
@@ -119,7 +119,6 @@
     </style>
 </head>
     <!-- CSP Local Authentication Protection -->
-    <script src="../js/auth-protection.js"></script>
     <style>
         /* Authentication header styles */
         #csp-auth-header {

--- a/enhanced_csp/frontend/pages/memory.html
+++ b/enhanced_csp/frontend/pages/memory.html
@@ -527,7 +527,6 @@
     </style>
 </head>
     <!-- CSP Local Authentication Protection -->
-    <script src="../js/auth-protection.js"></script>
     <style>
         /* Authentication header styles */
         #csp-auth-header {

--- a/enhanced_csp/frontend/pages/monitoring.html
+++ b/enhanced_csp/frontend/pages/monitoring.html
@@ -619,7 +619,6 @@
     </style>
 </head>
     <!-- CSP Local Authentication Protection -->
-    <script src="../js/auth-protection.js"></script>
     <style>
         /* Authentication header styles */
         #csp-auth-header {

--- a/enhanced_csp/frontend/pages/performance.html
+++ b/enhanced_csp/frontend/pages/performance.html
@@ -429,7 +429,6 @@
     </style>
 </head>
     <!-- CSP Local Authentication Protection -->
-    <script src="../js/auth-protection.js"></script>
     <style>
         /* Authentication header styles */
         #csp-auth-header {

--- a/enhanced_csp/frontend/pages/security.html
+++ b/enhanced_csp/frontend/pages/security.html
@@ -450,7 +450,6 @@
     </style>
 </head>
     <!-- CSP Local Authentication Protection -->
-    <script src="../js/auth-protection.js"></script>
     <style>
         /* Authentication header styles */
         #csp-auth-header {

--- a/enhanced_csp/frontend/pages/security_dashboard.html
+++ b/enhanced_csp/frontend/pages/security_dashboard.html
@@ -426,7 +426,6 @@
     </style>
 </head>
     <!-- CSP Local Authentication Protection -->
-    <script src="../js/auth-protection.js"></script>
     <style>
         /* Authentication header styles */
         #csp-auth-header {

--- a/enhanced_csp/frontend/pages/web_dashboard_ui.html
+++ b/enhanced_csp/frontend/pages/web_dashboard_ui.html
@@ -511,7 +511,6 @@
     </style>
 </head>
     <!-- CSP Local Authentication Protection -->
-    <script src="../js/auth-protection.js"></script>
     <style>
         /* Authentication header styles */
         #csp-auth-header {


### PR DESCRIPTION
## Summary
- remove auth-protection.js references from every frontend page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685c68ce15848328b86e217a7f033eaa