### PR TITLE
Remove onclick handlers from admin page

### DIFF
--- a/enhanced_csp/frontend/pages/admin.html
+++ b/enhanced_csp/frontend/pages/admin.html
@@ -58,15 +58,15 @@
         <nav class="sidebar" role="navigation" aria-label="Main navigation">
             <div class="nav-section">
                 <h3><i class="fas fa-chart-line"></i> System Overview</h3>
-                <div class="nav-item active" data-section="dashboard" onclick="showSection('dashboard')" role="button" tabindex="0" aria-label="Dashboard">
+                <div class="nav-item active" data-section="dashboard" role="button" tabindex="0" aria-label="Dashboard">
                     <span class="nav-icon"><i class="fas fa-home"></i></span>
                     <span>Dashboard</span>
                 </div>
-                <div class="nav-item" data-section="monitoring" onclick="showSection('monitoring')" role="button" tabindex="0" aria-label="System Monitoring">
+                <div class="nav-item" data-section="monitoring" role="button" tabindex="0" aria-label="System Monitoring">
                     <span class="nav-icon"><i class="fas fa-chart-bar"></i></span>
                     <span>System Monitoring</span>
                 </div>
-                <div class="nav-item" data-section="alerts" onclick="showSection('alerts')" role="button" tabindex="0" aria-label="Alerts & Incidents">
+                <div class="nav-item" data-section="alerts" role="button" tabindex="0" aria-label="Alerts & Incidents">
                     <span class="nav-icon"><i class="fas fa-exclamation-triangle"></i></span>
                     <span>Alerts & Incidents</span>
                 </div>
@@ -74,15 +74,15 @@
 
             <div class="nav-section">
                 <h3><i class="fas fa-users"></i> User Management</h3>
-                <div class="nav-item" data-section="users" onclick="showSection('users')" role="button" tabindex="0" aria-label="Users">
+                <div class="nav-item" data-section="users" role="button" tabindex="0" aria-label="Users">
                     <span class="nav-icon"><i class="fas fa-user"></i></span>
                     <span>Users</span>
                 </div>
-                <div class="nav-item" data-section="roles" onclick="showSection('roles')" role="button" tabindex="0" aria-label="Roles & Permissions">
+                <div class="nav-item" data-section="roles" role="button" tabindex="0" aria-label="Roles & Permissions">
                     <span class="nav-icon"><i class="fas fa-lock"></i></span>
                     <span>Roles & Permissions</span>
                 </div>
-                <div class="nav-item" data-section="auth" onclick="showSection('auth')" role="button" tabindex="0" aria-label="Authentication">
+                <div class="nav-item" data-section="auth" role="button" tabindex="0" aria-label="Authentication">
                     <span class="nav-icon"><i class="fas fa-key"></i></span>
                     <span>Authentication</span>
                 </div>
@@ -90,15 +90,15 @@
 
             <div class="nav-section">
                 <h3><i class="fas fa-robot"></i> AI Management</h3>
-                <div class="nav-item" data-section="ai-models" onclick="showSection('ai-models')" role="button" tabindex="0" aria-label="AI Models">
+                <div class="nav-item" data-section="ai-models" role="button" tabindex="0" aria-label="AI Models">
                     <span class="nav-icon"><i class="fas fa-brain"></i></span>
                     <span>AI Models</span>
                 </div>
-                <div class="nav-item" data-section="agents" onclick="showSection('agents')" role="button" tabindex="0" aria-label="Agent Management">
+                <div class="nav-item" data-section="agents" role="button" tabindex="0" aria-label="Agent Management">
                     <span class="nav-icon"><i class="fas fa-robot"></i></span>
                     <span>Agent Management</span>
                 </div>
-                <div class="nav-item" data-section="protocols" onclick="showSection('protocols')" role="button" tabindex="0" aria-label="Protocol Templates">
+                <div class="nav-item" data-section="protocols" role="button" tabindex="0" aria-label="Protocol Templates">
                     <span class="nav-icon"><i class="fas fa-clipboard-list"></i></span>
                     <span>Protocol Templates</span>
                 </div>
@@ -106,15 +106,15 @@
 
             <div class="nav-section">
                 <h3><i class="fas fa-cogs"></i> System Configuration</h3>
-                <div class="nav-item" data-section="settings" onclick="showSection('settings')" role="button" tabindex="0" aria-label="System Settings">
+                <div class="nav-item" data-section="settings" role="button" tabindex="0" aria-label="System Settings">
                     <span class="nav-icon"><i class="fas fa-cog"></i></span>
                     <span>System Settings</span>
                 </div>
-                <div class="nav-item" data-section="infrastructure" onclick="showSection('infrastructure')" role="button" tabindex="0" aria-label="Infrastructure">
+                <div class="nav-item" data-section="infrastructure" role="button" tabindex="0" aria-label="Infrastructure">
                     <span class="nav-icon"><i class="fas fa-server"></i></span>
                     <span>Infrastructure</span>
                 </div>
-                <div class="nav-item" data-section="integrations" onclick="showSection('integrations')" role="button" tabindex="0" aria-label="Integrations">
+                <div class="nav-item" data-section="integrations" role="button" tabindex="0" aria-label="Integrations">
                     <span class="nav-icon"><i class="fas fa-plug"></i></span>
                     <span>Integrations</span>
                 </div>
@@ -122,19 +122,19 @@
 
             <div class="nav-section">
                 <h3><i class="fas fa-shield-alt"></i> Security & Maintenance</h3>
-                <div class="nav-item" data-section="security" onclick="showSection('security')" role="button" tabindex="0" aria-label="Security Center">
+                <div class="nav-item" data-section="security" role="button" tabindex="0" aria-label="Security Center">
                     <span class="nav-icon"><i class="fas fa-shield-alt"></i></span>
                     <span>Security Center</span>
                 </div>
-                <div class="nav-item" data-section="backups" onclick="showSection('backups')" role="button" tabindex="0" aria-label="Backups & Recovery">
+                <div class="nav-item" data-section="backups" role="button" tabindex="0" aria-label="Backups & Recovery">
                     <span class="nav-icon"><i class="fas fa-download"></i></span>
                     <span>Backups & Recovery</span>
                 </div>
-                <div class="nav-item" data-section="logs" onclick="showSection('logs')" role="button" tabindex="0" aria-label="System Logs">
+                <div class="nav-item" data-section="logs" role="button" tabindex="0" aria-label="System Logs">
                     <span class="nav-icon"><i class="fas fa-file-alt"></i></span>
                     <span>System Logs</span>
                 </div>
-                <div class="nav-item" data-section="maintenance" onclick="showSection('maintenance')" role="button" tabindex="0" aria-label="Maintenance">
+                <div class="nav-item" data-section="maintenance" role="button" tabindex="0" aria-label="Maintenance">
                     <span class="nav-icon"><i class="fas fa-tools"></i></span>
                     <span>Maintenance</span>
                 </div>
@@ -142,15 +142,15 @@
 
             <div class="nav-section">
                 <h3><i class="fas fa-building"></i> Enterprise</h3>
-                <div class="nav-item" data-section="licenses" onclick="showSection('licenses')" role="button" tabindex="0" aria-label="Licenses">
+                <div class="nav-item" data-section="licenses" role="button" tabindex="0" aria-label="Licenses">
                     <span class="nav-icon"><i class="fas fa-certificate"></i></span>
                     <span>Licenses</span>
                 </div>
-                <div class="nav-item" data-section="billing" onclick="showSection('billing')" role="button" tabindex="0" aria-label="Billing & Usage">
+                <div class="nav-item" data-section="billing" role="button" tabindex="0" aria-label="Billing & Usage">
                     <span class="nav-icon"><i class="fas fa-credit-card"></i></span>
                     <span>Billing & Usage</span>
                 </div>
-                <div class="nav-item" data-section="audit" onclick="showSection('audit')" role="button" tabindex="0" aria-label="Audit Trail">
+                <div class="nav-item" data-section="audit" role="button" tabindex="0" aria-label="Audit Trail">
                     <span class="nav-icon"><i class="fas fa-search"></i></span>
                     <span>Audit Trail</span>
                 </div>


### PR DESCRIPTION
## Summary
- clean navigation markup in admin page by removing inline onclick handlers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_685dceee7f44832889e73683492c3657