### PR TITLE
Add admin user creation endpoint

### DIFF
--- a/enhanced_csp/backend/main.py
+++ b/enhanced_csp/backend/main.py
@@ -1264,6 +1264,22 @@ async def list_users(
         "total": len(local_users)
     }
 
+
+@app.post("/api/admin/users", response_model=LocalUserInfo, status_code=201, tags=["admin"])
+async def create_user(
+    user: LocalAuthSchemas.UserRegistration,
+    current_user: UnifiedUserInfo = Depends(require_role_unified(["admin", "super_admin"]))
+):
+    """Create a new local user (admin only)"""
+    try:
+        new_user = await local_auth_service.register_user(user)
+        return new_user
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Failed to create user: {e}")
+        raise HTTPException(status_code=500, detail="User creation failed")
+
 @app.get("/api/admin/audit-logs", tags=["admin"])
 async def get_audit_logs(
     limit: int = 100,

--- a/enhanced_csp/frontend/js/pages/admin/admin-modals.js
+++ b/enhanced_csp/frontend/js/pages/admin/admin-modals.js
@@ -1,6 +1,8 @@
 // Admin Portal Modal Functions Fix
 // Add this to your admin portal JavaScript or create a new admin-modals.js file
 
+const API_BASE_URL = 'http://localhost:8000';
+
 // Enhanced Modal Management System
 class AdminModalManager {
     constructor() {
@@ -387,16 +389,28 @@ class AdminModalManager {
     }
 
     async createUserAPI(userData) {
-        // Simulate API call
-        return new Promise((resolve, reject) => {
-            setTimeout(() => {
-                if (Math.random() > 0.1) { // 90% success rate
-                    resolve({ id: Date.now(), ...userData });
-                } else {
-                    reject(new Error('Network error'));
-                }
-            }, 1500);
+        const payload = {
+            email: userData.email_address,
+            password: userData.initial_password || 'ChangeMe123!',
+            confirm_password: userData.initial_password || 'ChangeMe123!',
+            full_name: userData.full_name
+        };
+
+        const response = await fetch(`${API_BASE_URL}/api/admin/users`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(payload)
         });
+
+        const data = await response.json();
+
+        if (!response.ok) {
+            throw new Error(data.detail || 'User creation failed');
+        }
+
+        return data;
     }
 
     async deployModelAPI(modelData) {


### PR DESCRIPTION
## Summary
- add POST `/api/admin/users` backend endpoint
- allow admin portal to create users via new endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*
- `python enhanced_csp/import_test.py`

------
https://chatgpt.com/codex/tasks/task_e_685dfa67fb988328abc74190c794d816