### PR TITLE
Add System Manager tab

### DIFF
--- a/enhanced_csp/frontend/js/pages/admin/admin.js
+++ b/enhanced_csp/frontend/js/pages/admin/admin.js
@@ -219,7 +219,11 @@ async function initializeSection(sectionId) {
             case 'maintenance':
                 await initializeMaintenance();
                 break;
-                
+
+            case 'system-manager':
+                await initializeSystemManager();
+                break;
+
             case 'licenses':
                 await initializeLicenses();
                 break;
@@ -455,6 +459,28 @@ async function initializeMaintenance() {
                     <i class="fas fa-wrench" style="font-size: 3rem; color: #ccc; margin-bottom: 1rem;"></i>
                     <p>Schedule and manage system maintenance tasks</p>
                 </div>
+            </div>
+        `;
+    }
+}
+
+async function initializeSystemManager() {
+    console.log('🖥️ Initializing System Manager...');
+    const section = document.getElementById('system-manager');
+
+    if (typeof SystemManager === 'undefined') {
+        try {
+            await loadScript('../js/pages/admin/systemManager.js');
+        } catch (error) {
+            console.error('❌ Failed to load SystemManager script:', error);
+        }
+    }
+
+    if (section && !section.querySelector('.system-manager-dashboard')) {
+        section.innerHTML = `
+            <div class="system-manager-dashboard">
+                <h2><i class="fas fa-cogs"></i> System Manager</h2>
+                <p>System manager will be populated by the SystemManager.</p>
             </div>
         `;
     }

--- a/enhanced_csp/frontend/pages/admin.html
+++ b/enhanced_csp/frontend/pages/admin.html
@@ -141,6 +141,10 @@
                     <span class="nav-icon"><i class="fas fa-tools"></i></span>
                     <span>Maintenance</span>
                 </div>
+                <div class="nav-item" data-section="system-manager" role="button" tabindex="0" aria-label="System Manager">
+                    <span class="nav-icon"><i class="fas fa-cogs"></i></span>
+                    <span>System Manager</span>
+                </div>
             </div>
 
             <div class="nav-section">
@@ -428,6 +432,11 @@
                 <p>Maintenance tools will be populated by the MaintenanceManager.</p>
             </section>
 
+            <section id="system-manager" class="content-section">
+                <h2 class="mb-3"><i class="fas fa-cogs"></i> System Manager</h2>
+                <p>System manager will be populated by the SystemManager.</p>
+            </section>
+
             <section id="licenses" class="content-section">
                 <h2 class="mb-3"><i class="fas fa-certificate"></i> Licenses</h2>
                 <p>License management will be populated by the LicenseManager.</p>
@@ -606,6 +615,7 @@
     
     <!-- Page Scripts -->
     <script src="../js/pages/admin/userManager.js"></script>
+    <script src="../js/pages/admin/systemManager.js"></script>
     <script src="../js/pages/admin/admin.js"></script>
     
     <!-- Accessibility Script -->


### PR DESCRIPTION
## Summary
- add System Manager tab under Security & Maintenance
- include System Manager content section
- load systemManager.js on admin page
- initialize new tab in admin.js

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e0ac6c694832892fa696ae3a2f129