### PR TITLE
Add infrastructure manager

### DIFF
--- a/enhanced_csp/frontend/css/pages/admin/infrastructure.css
+++ b/enhanced_csp/frontend/css/pages/admin/infrastructure.css
@@ -1,0 +1,20 @@
+/* Infrastructure Management Styles */
+
+.infrastructure-dashboard {
+    padding: var(--spacing-md, 1rem);
+}
+
+.infra-actions {
+    display: flex;
+    gap: 1rem;
+    margin-bottom: var(--spacing-md, 1rem);
+}
+
+.infra-status {
+    background: var(--card-bg, #1a1a1a);
+    border: 1px solid var(--border-color, #444);
+    border-radius: var(--border-radius-lg, 8px);
+    padding: var(--spacing-md, 1rem);
+    font-family: monospace;
+    white-space: pre-wrap;
+}

--- a/enhanced_csp/frontend/js/pages/admin/admin.js
+++ b/enhanced_csp/frontend/js/pages/admin/admin.js
@@ -374,18 +374,33 @@ async function initializeSettings() {
 
 async function initializeInfrastructure() {
     console.log('🏗️ Initializing Infrastructure...');
-    const infraSection = document.getElementById('infrastructure');
-    if (infraSection && !infraSection.querySelector('.infrastructure-dashboard')) {
-        infraSection.innerHTML = `
-            <div class="infrastructure-dashboard">
-                <h2><i class="fas fa-server"></i> Infrastructure Management</h2>
-                <p>Infrastructure monitoring and management will be implemented here.</p>
-                <div class="placeholder-content">
-                    <i class="fas fa-network-wired" style="font-size: 3rem; color: #ccc; margin-bottom: 1rem;"></i>
-                    <p>Monitor and manage system infrastructure</p>
+    if (typeof InfrastructureManager === 'undefined') {
+        try {
+            await loadScript('../js/pages/admin/infrastructureManager.js');
+        } catch (error) {
+            console.error('❌ Failed to load InfrastructureManager:', error);
+        }
+    }
+
+    if (window.infrastructureManager) {
+        window.infrastructureManager.refresh();
+    } else if (typeof InfrastructureManager !== 'undefined') {
+        window.infrastructureManager = new InfrastructureManager();
+        window.infrastructureManager.init();
+    } else {
+        const infraSection = document.getElementById('infrastructure');
+        if (infraSection && !infraSection.querySelector('.infrastructure-dashboard')) {
+            infraSection.innerHTML = `
+                <div class="infrastructure-dashboard">
+                    <h2><i class="fas fa-server"></i> Infrastructure Management</h2>
+                    <p>Infrastructure monitoring and management will be implemented here.</p>
+                    <div class="placeholder-content">
+                        <i class="fas fa-network-wired" style="font-size: 3rem; color: #ccc; margin-bottom: 1rem;"></i>
+                        <p>Monitor and manage system infrastructure</p>
+                    </div>
                 </div>
-            </div>
-        `;
+            `;
+        }
     }
 }
 

--- a/enhanced_csp/frontend/js/pages/admin/infrastructureManager.js
+++ b/enhanced_csp/frontend/js/pages/admin/infrastructureManager.js
@@ -1,0 +1,105 @@
+/**
+ * Infrastructure Manager
+ * Handles infrastructure status and integrates backup operations.
+ */
+class InfrastructureManager {
+    constructor() {
+        this.section = null;
+        this.status = null;
+        this.apiBaseUrl = this.getApiBaseUrl();
+        this.authToken = this.getAuthToken();
+    }
+
+    getApiBaseUrl() {
+        if (window.REACT_APP_CSP_API_URL) return window.REACT_APP_CSP_API_URL;
+        if (typeof REACT_APP_CSP_API_URL !== 'undefined') return REACT_APP_CSP_API_URL;
+        const meta = document.querySelector('meta[name="api-base-url"]');
+        if (meta) return meta.getAttribute('content');
+        if (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1') {
+            return 'http://localhost:8000';
+        }
+        return window.location.origin.replace(':3000', ':8000');
+    }
+
+    getAuthToken() {
+        return localStorage.getItem('csp_auth_token') || sessionStorage.getItem('csp_auth_token');
+    }
+
+    async apiRequest(endpoint, options = {}) {
+        const url = `${this.apiBaseUrl}${endpoint}`;
+        const defaultOptions = {
+            headers: {
+                'Content-Type': 'application/json',
+                ...(this.authToken && { 'Authorization': `Bearer ${this.authToken}` })
+            }
+        };
+        const response = await fetch(url, { ...defaultOptions, ...options });
+        if (!response.ok) {
+            const data = await response.json().catch(() => ({}));
+            throw new Error(data.detail || `HTTP ${response.status}`);
+        }
+        if (response.status === 204) return null;
+        return response.json();
+    }
+
+    async init() {
+        this.section = document.getElementById('infrastructure');
+        if (!this.section) return;
+        await this.loadStatus();
+        this.render();
+        this.attachEvents();
+    }
+
+    async loadStatus() {
+        try {
+            this.status = await this.apiRequest('/api/infrastructure/status');
+        } catch (err) {
+            console.warn('Failed to load infrastructure status', err);
+            this.status = { message: 'Status unavailable' };
+        }
+    }
+
+    render() {
+        const statusText = this.status ? JSON.stringify(this.status, null, 2) : 'No status available';
+        this.section.innerHTML = `
+            <div class="infrastructure-dashboard">
+                <div class="infra-actions">
+                    <button class="btn btn-primary" id="infra-backup-btn">
+                        <i class="fas fa-download"></i> Create Backup
+                    </button>
+                    <button class="btn btn-secondary" id="infra-refresh-btn">
+                        <i class="fas fa-sync-alt"></i> Refresh
+                    </button>
+                </div>
+                <div class="infra-status">
+                    <h3>Current Status</h3>
+                    <pre>${statusText}</pre>
+                </div>
+            </div>
+        `;
+    }
+
+    attachEvents() {
+        this.section.querySelector('#infra-backup-btn')?.addEventListener('click', () => this.createBackup());
+        this.section.querySelector('#infra-refresh-btn')?.addEventListener('click', () => this.refresh());
+    }
+
+    async refresh() {
+        await this.loadStatus();
+        this.render();
+    }
+
+    async createBackup() {
+        try {
+            await this.apiRequest('/api/backups', { method: 'POST' });
+            alert('Backup created successfully');
+        } catch (err) {
+            console.error('Failed to create backup', err);
+            alert('Failed to create backup');
+        }
+    }
+}
+
+const infrastructureManager = new InfrastructureManager();
+
+document.addEventListener('DOMContentLoaded', () => infrastructureManager.init());

--- a/enhanced_csp/frontend/pages/admin.html
+++ b/enhanced_csp/frontend/pages/admin.html
@@ -29,6 +29,7 @@
     <link rel="stylesheet" href="../css/pages/admin/alerts_incidents.css">
     <link rel="stylesheet" href="../css/pages/admin/roles.css">
     <link rel="stylesheet" href="../css/pages/admin/backups.css">
+    <link rel="stylesheet" href="../css/pages/admin/infrastructure.css">
     <script src="../js/pages/admin/alerts_incidents.js" defer></script>
 </head>
 <body>
@@ -349,6 +350,7 @@
     <script src="../js/pages/admin/userManager.js"></script>
     <script src="../js/pages/admin/systemManager.js"></script>
     <script src="../js/pages/admin/backupsManager.js"></script>
+    <script src="../js/pages/admin/infrastructureManager.js"></script>
     <script src="../js/pages/admin/admin.js"></script>
 
     


### PR DESCRIPTION
## Summary
- add Infrastructure section styles
- create InfrastructureManager to manage status and backup
- link infrastructure scripts and styles in admin portal
- initialize InfrastructureManager from admin.js

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_685e325eafc08328bd5e3b09c48ee005