### PR TITLE
Implement System Settings tab

### DIFF
--- a/enhanced_csp/backend/api/endpoints/settings.py
+++ b/enhanced_csp/backend/api/endpoints/settings.py
@@ -1,0 +1,18 @@
+from fastapi import APIRouter, Depends
+from typing import Dict, Any, List
+
+from backend.config.settings import settings, reload_configuration
+
+router = APIRouter(prefix="/api/settings", tags=["settings"])
+
+@router.get("/", response_model=Dict[str, Any])
+async def read_settings():
+    return {"settings": settings.model_dump()}
+
+@router.put("/", response_model=Dict[str, str])
+async def update_settings(payload: Dict[str, List[Dict[str, Any]]]):
+    for item in payload.get("settings", []):
+        if hasattr(settings, item["key"]):
+            setattr(settings, item["key"], item["value"])
+    reload_configuration()
+    return {"message": "updated"}

--- a/enhanced_csp/backend/main.py
+++ b/enhanced_csp/backend/main.py
@@ -935,6 +935,14 @@ except ImportError:
     logger.warning("⚠️ Infrastructure router not available")
     INFRASTRUCTURE_AVAILABLE = False
 
+# Include system settings router
+try:
+    from backend.api.endpoints import settings as settings_router
+    app.include_router(settings_router.router)
+    logger.info("✅ Settings router registered")
+except ImportError:
+    logger.warning("⚠️ Settings router not available")
+
 # ============================================================================
 # AUTHENTICATION ENDPOINTS
 # ============================================================================

--- a/enhanced_csp/frontend/js/pages/admin/admin.js
+++ b/enhanced_csp/frontend/js/pages/admin/admin.js
@@ -357,18 +357,11 @@ async function initializeProtocols() {
 
 async function initializeSettings() {
     console.log('⚙️ Initializing System Settings...');
-    const settingsSection = document.getElementById('settings');
-    if (settingsSection && !settingsSection.querySelector('.settings-dashboard')) {
-        settingsSection.innerHTML = `
-            <div class="settings-dashboard">
-                <h2><i class="fas fa-cog"></i> System Settings</h2>
-                <p>System configuration settings will be implemented here.</p>
-                <div class="placeholder-content">
-                    <i class="fas fa-sliders-h" style="font-size: 3rem; color: #ccc; margin-bottom: 1rem;"></i>
-                    <p>Configure system-wide settings and preferences</p>
-                </div>
-            </div>
-        `;
+    const settingsSection = document.getElementById('system-settings');
+    if (settingsSection && !window.systemManager) {
+        await loadScript('../js/pages/admin/systemManager.js');
+        window.systemManager = new SystemManager();
+        settingsSection.classList.remove('hidden');
     }
 }
 

--- a/enhanced_csp/frontend/pages/admin.html
+++ b/enhanced_csp/frontend/pages/admin.html
@@ -30,6 +30,7 @@
     <link rel="stylesheet" href="../css/pages/admin/roles.css">
     <link rel="stylesheet" href="../css/pages/admin/backups.css">
     <link rel="stylesheet" href="../css/pages/admin/infrastructure.css">
+    <link rel="stylesheet" href="../css/pages/admin/systemManager.css">
     <script src="../js/pages/admin/alerts_incidents.js" defer></script>
 </head>
 <body>
@@ -281,9 +282,9 @@
                 <p>Protocol templates will be populated by the ProtocolManager.</p>
             </section>
 
-            <section id="settings" class="content-section">
+            <section id="system-settings" class="content-section hidden">
                 <h2 class="mb-3"><i class="fas fa-cog"></i> System Settings</h2>
-                <p>System settings will be populated by the SettingsManager.</p>
+                <div id="settings-form-container"></div>
             </section>
 
             <section id="infrastructure" class="content-section">


### PR DESCRIPTION
## Summary
- add CSS link for System Settings UI
- add container for System Settings section
- initialize SystemManager dynamically
- expose `/api/settings` routes
- register new settings router

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiosqlite')*

------
https://chatgpt.com/codex/tasks/task_e_685e40f7cf9c83289b2df1f517109421