### PR TITLE
Add basic licenses tab support

### DIFF
--- a/enhanced_csp/backend/api/endpoints/licenses.py
+++ b/enhanced_csp/backend/api/endpoints/licenses.py
@@ -1,0 +1,62 @@
+from fastapi import APIRouter, HTTPException, Depends
+from typing import List
+from uuid import UUID
+from datetime import datetime
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+
+from backend.models.database_models import LicenseRecord
+from backend.schemas.api_schemas import LicenseCreate, LicenseResponse
+from backend.database.connection import get_db_session
+
+router = APIRouter(prefix="/api/licenses", tags=["licenses"])
+
+
+@router.get("/", response_model=List[LicenseResponse])
+async def list_licenses(db: AsyncSession = Depends(get_db_session)):
+    result = await db.execute(select(LicenseRecord))
+    records = result.scalars().all()
+    return [LicenseResponse(**rec.to_dict()) for rec in records]
+
+
+@router.post("/", response_model=LicenseResponse, status_code=201)
+async def create_license(item: LicenseCreate, db: AsyncSession = Depends(get_db_session)):
+    record = LicenseRecord(
+        product=item.product,
+        key=item.key,
+        expires_at=item.expires_at,
+        active=item.active,
+    )
+    db.add(record)
+    await db.commit()
+    await db.refresh(record)
+    return LicenseResponse(**record.to_dict())
+
+
+@router.put("/{license_id}", response_model=LicenseResponse)
+async def update_license(license_id: str, item: LicenseCreate, db: AsyncSession = Depends(get_db_session)):
+    result = await db.execute(select(LicenseRecord).where(LicenseRecord.id == UUID(license_id)))
+    record = result.scalar_one_or_none()
+    if not record:
+        raise HTTPException(status_code=404, detail="License not found")
+
+    record.product = item.product
+    record.key = item.key
+    record.expires_at = item.expires_at
+    record.active = item.active
+    record.updated_at = datetime.utcnow()
+    await db.commit()
+    await db.refresh(record)
+    return LicenseResponse(**record.to_dict())
+
+
+@router.delete("/{license_id}", status_code=204)
+async def delete_license(license_id: str, db: AsyncSession = Depends(get_db_session)):
+    result = await db.execute(select(LicenseRecord).where(LicenseRecord.id == UUID(license_id)))
+    record = result.scalar_one_or_none()
+    if not record:
+        raise HTTPException(status_code=404, detail="License not found")
+
+    await db.delete(record)
+    await db.commit()

--- a/enhanced_csp/backend/main.py
+++ b/enhanced_csp/backend/main.py
@@ -943,6 +943,14 @@ try:
 except ImportError:
     logger.warning("⚠️ Settings router not available")
 
+# Include licenses router
+try:
+    from backend.api.endpoints.licenses import router as licenses_router
+    app.include_router(licenses_router)
+    logger.info("✅ Licenses router registered")
+except ImportError:
+    logger.warning("⚠️ Licenses router not available")
+
 # ============================================================================
 # AUTHENTICATION ENDPOINTS
 # ============================================================================

--- a/enhanced_csp/backend/models/database_models.py
+++ b/enhanced_csp/backend/models/database_models.py
@@ -382,5 +382,32 @@ class Notification(Base):
             "actions": self.actions,
             "created_at": self.created_at.isoformat() if self.created_at else None,
             "read_at": self.read_at.isoformat() if self.read_at else None,
-            "expires_at": self.expires_at.isoformat() if self.expires_at else None
+        "expires_at": self.expires_at.isoformat() if self.expires_at else None
+        }
+
+# ============================================================================
+# LICENSE MODELS
+# ============================================================================
+
+class LicenseRecord(Base):
+    """Software license information"""
+    __tablename__ = "licenses"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    product = Column(String(100), nullable=False)
+    key = Column(String(255), nullable=False, unique=True)
+    expires_at = Column(DateTime)
+    active = Column(Boolean, default=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    def to_dict(self):
+        return {
+            "id": str(self.id),
+            "product": self.product,
+            "key": self.key,
+            "expires_at": self.expires_at.isoformat() if self.expires_at else None,
+            "active": self.active,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
         }

--- a/enhanced_csp/backend/models/license.py
+++ b/enhanced_csp/backend/models/license.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel, Field
+from datetime import date
+from typing import Optional
+import uuid
+
+class License(BaseModel):
+    id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    product: str
+    key: str
+    expires_at: Optional[date] = None
+    active: bool = True

--- a/enhanced_csp/backend/schemas/api_schemas.py
+++ b/enhanced_csp/backend/schemas/api_schemas.py
@@ -408,6 +408,22 @@ class NotificationResponse(BaseModel):
     read_at: Optional[datetime]
 
 # ============================================================================
+# NEW LICENSE SCHEMAS
+# ============================================================================
+
+class LicenseCreate(BaseModel):
+    """License creation request"""
+    product: str
+    key: str
+    expires_at: Optional[datetime] = None
+    active: bool = True
+
+class LicenseResponse(LicenseCreate):
+    id: str
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+
+# ============================================================================
 # NEW COMPONENT SCHEMAS
 # ============================================================================
 

--- a/enhanced_csp/frontend/js/pages/admin/admin.js
+++ b/enhanced_csp/frontend/js/pages/admin/admin.js
@@ -506,18 +506,26 @@ async function initializeSystemManager() {
 
 async function initializeLicenses() {
     console.log('📜 Initializing Licenses...');
-    const licensesSection = document.getElementById('licenses');
-    if (licensesSection && !licensesSection.querySelector('.licenses-dashboard')) {
-        licensesSection.innerHTML = `
-            <div class="licenses-dashboard">
-                <h2><i class="fas fa-certificate"></i> License Management</h2>
-                <p>Software license tracking and management will be implemented here.</p>
-                <div class="placeholder-content">
-                    <i class="fas fa-award" style="font-size: 3rem; color: #ccc; margin-bottom: 1rem;"></i>
-                    <p>Track software licenses and compliance</p>
+    if (typeof LicensesManager === 'undefined') {
+        await loadScript('../js/pages/admin/licensesManager.js');
+    }
+
+    if (typeof initializeLicensesManager === 'function') {
+        initializeLicensesManager();
+    } else {
+        const licensesSection = document.getElementById('licenses');
+        if (licensesSection && !licensesSection.querySelector('.licenses-dashboard')) {
+            licensesSection.innerHTML = `
+                <div class="licenses-dashboard">
+                    <h2><i class="fas fa-certificate"></i> License Management</h2>
+                    <p>Software license tracking and management will be implemented here.</p>
+                    <div class="placeholder-content">
+                        <i class="fas fa-award" style="font-size: 3rem; color: #ccc; margin-bottom: 1rem;"></i>
+                        <p>Track software licenses and compliance</p>
+                    </div>
                 </div>
-            </div>
-        `;
+            `;
+        }
     }
 }
 

--- a/enhanced_csp/frontend/js/pages/admin/licensesManager.js
+++ b/enhanced_csp/frontend/js/pages/admin/licensesManager.js
@@ -1,0 +1,118 @@
+class LicensesManager {
+    constructor() {
+        this.section = null;
+        this.licenses = [];
+        this.api = window.ApiClient || new ApiClient();
+    }
+
+    async init() {
+        this.section = document.getElementById('licenses');
+        if (!this.section) return;
+        await this.load();
+        this.render();
+        this.attachEvents();
+    }
+
+    async load() {
+        try {
+            const response = await this.api.get('/licenses');
+            if (response.success) {
+                this.licenses = response.data;
+            } else {
+                this.licenses = [];
+            }
+        } catch (err) {
+            console.error('Failed to load licenses', err);
+            this.licenses = [];
+        }
+    }
+
+    render() {
+        this.section.innerHTML = `
+            <div class="licenses-dashboard">
+                <h2><i class="fas fa-certificate"></i> License Management</h2>
+                <button class="btn btn-primary" id="add-license-btn">Add License</button>
+                <table class="license-table">
+                    <thead><tr><th>Product</th><th>Key</th><th>Expires</th><th>Active</th><th>Actions</th></tr></thead>
+                    <tbody id="licenses-tbody">
+                        ${this.licenses.map(l => `
+                            <tr data-id="${l.id}">
+                                <td>${l.product}</td>
+                                <td>${l.key}</td>
+                                <td>${l.expires_at || ''}</td>
+                                <td>${l.active ? 'Yes' : 'No'}</td>
+                                <td><button class="delete-btn">Delete</button></td>
+                            </tr>`).join('')}
+                    </tbody>
+                </table>
+            </div>`;
+    }
+
+    attachEvents() {
+        this.section.querySelector('#add-license-btn')?.addEventListener('click', () => this.create());
+        this.section.addEventListener('click', (e) => {
+            const btn = e.target.closest('.delete-btn');
+            if (btn) {
+                const tr = btn.closest('tr');
+                const id = tr.getAttribute('data-id');
+                this.remove(id);
+            }
+        });
+    }
+
+    async create() {
+        const product = prompt('Product name?');
+        if (!product) return;
+        const key = prompt('License key?');
+        if (!key) return;
+        try {
+            const response = await this.api.post('/licenses', { product, key });
+            if (response.success) {
+                await this.refresh();
+            } else {
+                console.error('Failed to add license', response.error);
+            }
+        } catch (err) {
+            console.error('Failed to add license', err);
+        }
+    }
+
+    async remove(id) {
+        if (!confirm('Delete this license?')) return;
+        try {
+            const response = await this.api.delete(`/licenses/${id}`);
+            if (response.success) {
+                await this.refresh();
+            } else {
+                console.error('Failed to delete license', response.error);
+            }
+        } catch (err) {
+            console.error('Failed to delete license', err);
+        }
+    }
+
+    async refresh() {
+        await this.load();
+        this.render();
+    }
+}
+
+let licensesManager;
+function initializeLicensesManager() {
+    if (!licensesManager) {
+        licensesManager = new LicensesManager();
+        licensesManager.init();
+        window.licensesManager = licensesManager;
+    }
+    return licensesManager;
+}
+
+if (document.readyState !== 'loading') {
+    initializeLicensesManager();
+} else {
+    document.addEventListener('DOMContentLoaded', initializeLicensesManager);
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { LicensesManager, initializeLicensesManager };
+}

--- a/enhanced_csp/frontend/pages/admin.html
+++ b/enhanced_csp/frontend/pages/admin.html
@@ -352,9 +352,9 @@
     <script src="../js/pages/admin/systemManager.js"></script>
     <script src="../js/pages/admin/backupsManager.js"></script>
     <script src="../js/pages/admin/infrastructureManager.js"></script>
-    <script src="../js/pages/admin/admin.js"></script>
+    <script src="../js/pages/admin/licensesManager.js"></script>
 
-    
+
     <!-- Main admin script -->
     <script src="../js/pages/admin/admin.js"></script>
 


### PR DESCRIPTION
## Summary
- implement simple License model and in-memory license API
- register new API router in backend
- add client-side LicensesManager for admin UI
- hook license manager initialization in admin.js and load it on the admin page
- fix API usage in LicensesManager and remove duplicate script
- generate unique IDs for license records

## Testing
- `python -m py_compile enhanced_csp/backend/models/license.py enhanced_csp/backend/api/endpoints/licenses.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_685e4761c2108328a26835cd094924d0