### PR TITLE
Add refresh methods and error handling

### DIFF
--- a/enhanced_csp/frontend/js/pages/admin/admin.js
+++ b/enhanced_csp/frontend/js/pages/admin/admin.js
@@ -376,10 +376,18 @@ async function initializeInfrastructure() {
     }
 
     if (window.infrastructureManager) {
-        window.infrastructureManager.refresh();
+        if (typeof window.infrastructureManager.refresh === 'function') {
+            window.infrastructureManager.refresh();
+        } else if (typeof window.infrastructureManager.init === 'function') {
+            window.infrastructureManager.init();
+        } else {
+            console.warn('InfrastructureManager is missing required methods');
+        }
     } else if (typeof InfrastructureManager !== 'undefined') {
         window.infrastructureManager = new InfrastructureManager();
-        window.infrastructureManager.init();
+        if (typeof window.infrastructureManager.init === 'function') {
+            window.infrastructureManager.init();
+        }
     } else {
         const infraSection = document.getElementById('infrastructure');
         if (infraSection && !infraSection.querySelector('.infrastructure-dashboard')) {

--- a/enhanced_csp/frontend/js/pages/admin/systemManager.js
+++ b/enhanced_csp/frontend/js/pages/admin/systemManager.js
@@ -799,6 +799,11 @@ class SystemManager {
     }
   }
 
+  async refresh() {
+    await this.loadSettings();
+    this.renderForm();
+  }
+
   async apiRequest(endpoint, options = {}) {
     const url = `${this.apiBaseUrl}${endpoint}`;
     const defaultOptions = {

--- a/enhanced_csp/frontend/js/pages/admin/userManager.js
+++ b/enhanced_csp/frontend/js/pages/admin/userManager.js
@@ -469,7 +469,7 @@ class UserManager {
         // Refresh button
         const refreshBtn = this.section.querySelector('#refresh-users-btn');
         if (refreshBtn) {
-            refreshBtn.addEventListener('click', () => this.loadUsers(this.pagination.page));
+            refreshBtn.addEventListener('click', () => this.refresh());
         }
 
         // Export button
@@ -661,6 +661,10 @@ class UserManager {
         } catch (error) {
             console.error('Failed to export users:', error);
         }
+    }
+
+    async refresh() {
+        await this.loadUsers(this.pagination.page);
     }
 
     formatDate(dateString) {


### PR DESCRIPTION
## Summary
- implement refresh() for UserManager and SystemManager
- hook refresh button to the new function
- guard infrastructureManager refreshing in admin.js

## Testing
- `pytest -q` *(fails: UnsupportedCompilationError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_685ef086ee0883289d37d21cce347c83