### PR TITLE
Improve API fallback handling

### DIFF
--- a/enhanced_csp/frontend/js/pages/admin/infrastructureManager.js
+++ b/enhanced_csp/frontend/js/pages/admin/infrastructureManager.js
@@ -149,8 +149,13 @@ class InfrastructureManager {
         while (retries < this.config.maxRetries) {
             try {
                 const response = await fetch(url, { ...defaultOptions, ...options });
-                
+
                 if (!response.ok) {
+                    const key = endpoint.split('?')[0];
+                    if (response.status === 404 && window.apiFallbackData && window.apiFallbackData[key]) {
+                        console.warn(`Endpoint not found: ${endpoint}. Using fallback data.`);
+                        return window.apiFallbackData[key];
+                    }
                     const errorData = await response.json().catch(() => ({}));
                     throw new Error(errorData.detail || `HTTP ${response.status}: ${response.statusText}`);
                 }

--- a/enhanced_csp/frontend/js/utils/apiFallbackData.js
+++ b/enhanced_csp/frontend/js/utils/apiFallbackData.js
@@ -1,0 +1,24 @@
+window.apiFallbackData = {
+  '/metrics': {
+    active_processes: 0,
+    quantum_entanglements: 0,
+    blockchain_transactions: 0,
+    neural_efficiency: 100,
+    security_threats: 0,
+    system_uptime: 100,
+    cpu_usage: 0,
+    memory_usage: 0
+  },
+  '/processes': {
+    processes: [],
+    count: 0
+  },
+  '/api/infrastructure/metrics': {
+    cpu: { current: 45, max: 100, unit: '%' },
+    memory: { current: 62, max: 100, unit: '%' },
+    disk: { current: 78, max: 100, unit: '%' },
+    network: { current: 23, max: 100, unit: '%' },
+    uptime: { current: 99.5, max: 100, unit: '%' },
+    requests: { current: 1250, max: null, unit: '/min' }
+  }
+};

--- a/enhanced_csp/frontend/pages/admin.html
+++ b/enhanced_csp/frontend/pages/admin.html
@@ -415,6 +415,7 @@
     <!-- Shared JavaScript Dependencies -->
     <script src="../js/shared/BaseComponent.js"></script>
     <script src="../js/shared/SharedComponents.js"></script>
+    <script src="../js/utils/apiFallbackData.js"></script>
     <script src="../js/utils/ApiClient.js"></script>
     
     <!-- Page-specific JavaScript Modules -->

--- a/enhanced_csp/frontend/pages/web_dashboard_ui.html
+++ b/enhanced_csp/frontend/pages/web_dashboard_ui.html
@@ -852,6 +852,7 @@
     </div>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/3.9.1/chart.min.js"></script>
+    <script src="../js/utils/apiFallbackData.js"></script>
     <script>
         // Dashboard JavaScript
         class EnhancedCSPDashboard {
@@ -940,12 +941,37 @@
             }
 
             setupPolling() {
-                setInterval(() => {
-                    fetch('/api/metrics')
-                        .then(response => response.json())
-                        .then(data => this.handleRealTimeUpdate(data))
-                        .catch(error => console.error('Polling error:', error));
+                setInterval(async () => {
+                    try {
+                        const response = await fetch('/api/metrics');
+                        if (response.ok) {
+                            const data = await response.json();
+                            this.handleRealTimeUpdate(data);
+                        } else if (response.status === 404) {
+                            console.warn('Metrics API returned 404 - using fallback data');
+                            this.handleRealTimeUpdate(this.getMockMetrics());
+                        } else {
+                            console.error('Polling error:', response.statusText);
+                        }
+                    } catch (error) {
+                        console.error('Polling error:', error);
+                        this.handleRealTimeUpdate(this.getMockMetrics());
+                    }
                 }, 5000);
+            }
+
+            getMockMetrics() {
+                return window.apiFallbackData && window.apiFallbackData['/metrics'] ?
+                    { ...window.apiFallbackData['/metrics'] } : {
+                        active_processes: 0,
+                        quantum_entanglements: 0,
+                        blockchain_transactions: 0,
+                        neural_efficiency: 100,
+                        security_threats: 0,
+                        system_uptime: 100,
+                        cpu_usage: 0,
+                        memory_usage: 0
+                    };
             }
 
             handleRealTimeUpdate(data) {


### PR DESCRIPTION
## Summary
- provide API fallback capability in `ApiClient`
- bundle sample fallback mock data
- use fallback in `web_dashboard_ui` when metrics API fails
- load fallback on `admin.html` and add fallback for infrastructure metrics

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685ef094db508328b3e9b68a4eef3663