### PR TITLE
Centralize frontend mock data

### DIFF
--- a/enhanced_csp/frontend/js/pages/admin/components/StatsGrid.js
+++ b/enhanced_csp/frontend/js/pages/admin/components/StatsGrid.js
@@ -17,18 +17,7 @@ class StatsGrid extends BaseComponent {
         };
         
         this.refreshTimer = null;
-        this.mockData = this.generateMockData();
-    }
-    
-    generateMockData() {
-        return {
-            totalAgents: Math.floor(Math.random() * 50) + 10,
-            activeAgents: Math.floor(Math.random() * 30) + 5,
-            totalExecutions: Math.floor(Math.random() * 10000) + 1000,
-            successRate: Math.random() * 20 + 80, // 80-100%
-            averageResponseTime: Math.random() * 500 + 100, // 100-600ms
-            systemUptime: Math.random() * 720 + 720 // 12-36 hours in minutes
-        };
+        this.mockData = window.apiFallbackData.generateStatsGridData();
     }
     
     render() {
@@ -153,7 +142,7 @@ class StatsGrid extends BaseComponent {
             await new Promise(resolve => setTimeout(resolve, 500));
             
             // Update mock data
-            this.mockData = this.generateMockData();
+            this.mockData = window.apiFallbackData.generateStatsGridData();
             
             this.setState({
                 stats: this.mockData,

--- a/enhanced_csp/frontend/js/pages/admin/infrastructureManager.js
+++ b/enhanced_csp/frontend/js/pages/admin/infrastructureManager.js
@@ -239,25 +239,12 @@ class InfrastructureManager {
     }
 
     initializeDefaultMetrics() {
-        const defaultMetrics = {
-            cpu: { current: 45, max: 100, unit: '%' },
-            memory: { current: 62, max: 100, unit: '%' },
-            disk: { current: 78, max: 100, unit: '%' },
-            network: { current: 23, max: 100, unit: '%' },
-            uptime: { current: 99.5, max: 100, unit: '%' },
-            requests: { current: 1250, max: null, unit: '/min' }
-        };
+        const defaultMetrics = window.apiFallbackData['/api/infrastructure/metrics'];
         this.updateMetrics(defaultMetrics);
     }
 
     initializeDefaultServices() {
-        const defaultServices = [
-            { name: 'Web Server', status: 'running', uptime: '15d 4h 23m', port: 80 },
-            { name: 'Database', status: 'running', uptime: '15d 4h 23m', port: 5432 },
-            { name: 'Redis Cache', status: 'running', uptime: '15d 4h 23m', port: 6379 },
-            { name: 'API Gateway', status: 'running', uptime: '15d 4h 23m', port: 8000 },
-            { name: 'Message Queue', status: 'warning', uptime: '2d 1h 15m', port: 5672 }
-        ];
+        const defaultServices = window.apiFallbackData['/api/infrastructure/services'];
         defaultServices.forEach(service => {
             this.services.set(service.name, service);
         });
@@ -303,8 +290,7 @@ class InfrastructureManager {
 
     getMetricHistory(metric) {
         // This would typically come from a time series database
-        // For now, return mock data
-        return [45, 47, 46, 48, 50];
+        return window.apiFallbackData.infrastructureMetricHistory;
     }
 
     checkThreshold(metric, value) {

--- a/enhanced_csp/frontend/js/pages/admin/systemManager.js
+++ b/enhanced_csp/frontend/js/pages/admin/systemManager.js
@@ -164,7 +164,7 @@ class SystemManager {
         }
       } catch (apiError) {
         console.warn('API not available, using mock data:', apiError);
-        this.settings = this.getMockSettings();
+        this.settings = window.apiFallbackData['/api/settings'];
       }
       
       // Store original values for reset functionality
@@ -179,31 +179,12 @@ class SystemManager {
       this.showToast('Failed to load settings', 'error');
       
       // Fallback to mock data
-      this.settings = this.getMockSettings();
+      this.settings = window.apiFallbackData['/api/settings'];
     } finally {
       this.setLoading(false);
     }
   }
 
-  getMockSettings() {
-    return [
-      { key: 'app_name', value: 'Enhanced CSP System', description: 'Application name', widget: 'text', category: 'Application' },
-      { key: 'debug', value: false, description: 'Enable debug mode', widget: 'switch', category: 'Application' },
-      { key: 'environment', value: 'development', description: 'Application environment', widget: 'select', options: ['development', 'testing', 'staging', 'production'], category: 'Application' },
-      { key: 'enable_ai', value: true, description: 'Enable AI features', widget: 'switch', category: 'Features' },
-      { key: 'enable_websockets', value: true, description: 'Enable WebSocket support', widget: 'switch', category: 'Features' },
-      { key: 'database_host', value: 'localhost', description: 'Database host address', widget: 'text', category: 'Database' },
-      { key: 'database_port', value: 5432, description: 'Database port', widget: 'number', category: 'Database' },
-      { key: 'database_pool_size', value: 20, description: 'Database connection pool size', widget: 'number', category: 'Database' },
-      { key: 'redis_host', value: 'localhost', description: 'Redis host address', widget: 'text', category: 'Cache' },
-      { key: 'redis_port', value: 6379, description: 'Redis port', widget: 'number', category: 'Cache' },
-      { key: 'ai_max_requests_per_minute', value: 60, description: 'AI API rate limit (requests/min)', widget: 'number', category: 'AI' },
-      { key: 'ai_max_daily_cost', value: 100.0, description: 'Maximum daily AI cost limit ($)', widget: 'number', category: 'AI' },
-      { key: 'security_max_login_attempts', value: 5, description: 'Maximum login attempts before lockout', widget: 'number', category: 'Security' },
-      { key: 'api_rate_limit_requests_per_minute', value: 100, description: 'API rate limit (requests/min/user)', widget: 'number', category: 'API' },
-      { key: 'log_level', value: 'INFO', description: 'Application log level', widget: 'select', options: ['DEBUG', 'INFO', 'WARNING', 'ERROR'], category: 'Monitoring' }
-    ];
-  }
 
   renderForm() {
     if (!this.formContainer) return;

--- a/enhanced_csp/frontend/js/utils/apiFallbackData.js
+++ b/enhanced_csp/frontend/js/utils/apiFallbackData.js
@@ -20,5 +20,44 @@ window.apiFallbackData = {
     network: { current: 23, max: 100, unit: '%' },
     uptime: { current: 99.5, max: 100, unit: '%' },
     requests: { current: 1250, max: null, unit: '/min' }
+  },
+
+  '/api/infrastructure/services': [
+    { name: 'Web Server', status: 'running', uptime: '15d 4h 23m', port: 80 },
+    { name: 'Database', status: 'running', uptime: '15d 4h 23m', port: 5432 },
+    { name: 'Redis Cache', status: 'running', uptime: '15d 4h 23m', port: 6379 },
+    { name: 'API Gateway', status: 'running', uptime: '15d 4h 23m', port: 8000 },
+    { name: 'Message Queue', status: 'warning', uptime: '2d 1h 15m', port: 5672 }
+  ],
+
+  '/api/settings': [
+    { key: 'app_name', value: 'Enhanced CSP System', description: 'Application name', widget: 'text', category: 'Application' },
+    { key: 'debug', value: false, description: 'Enable debug mode', widget: 'switch', category: 'Application' },
+    { key: 'environment', value: 'development', description: 'Application environment', widget: 'select', options: ['development', 'testing', 'staging', 'production'], category: 'Application' },
+    { key: 'enable_ai', value: true, description: 'Enable AI features', widget: 'switch', category: 'Features' },
+    { key: 'enable_websockets', value: true, description: 'Enable WebSocket support', widget: 'switch', category: 'Features' },
+    { key: 'database_host', value: 'localhost', description: 'Database host address', widget: 'text', category: 'Database' },
+    { key: 'database_port', value: 5432, description: 'Database port', widget: 'number', category: 'Database' },
+    { key: 'database_pool_size', value: 20, description: 'Database connection pool size', widget: 'number', category: 'Database' },
+    { key: 'redis_host', value: 'localhost', description: 'Redis host address', widget: 'text', category: 'Cache' },
+    { key: 'redis_port', value: 6379, description: 'Redis port', widget: 'number', category: 'Cache' },
+    { key: 'ai_max_requests_per_minute', value: 60, description: 'AI API rate limit (requests/min)', widget: 'number', category: 'AI' },
+    { key: 'ai_max_daily_cost', value: 100.0, description: 'Maximum daily AI cost limit ($)', widget: 'number', category: 'AI' },
+    { key: 'security_max_login_attempts', value: 5, description: 'Maximum login attempts before lockout', widget: 'number', category: 'Security' },
+    { key: 'api_rate_limit_requests_per_minute', value: 100, description: 'API rate limit (requests/min/user)', widget: 'number', category: 'API' },
+    { key: 'log_level', value: 'INFO', description: 'Application log level', widget: 'select', options: ['DEBUG', 'INFO', 'WARNING', 'ERROR'], category: 'Monitoring' }
+  ],
+
+  infrastructureMetricHistory: [45, 47, 46, 48, 50],
+
+  generateStatsGridData() {
+    return {
+      totalAgents: Math.floor(Math.random() * 50) + 10,
+      activeAgents: Math.floor(Math.random() * 30) + 5,
+      totalExecutions: Math.floor(Math.random() * 10000) + 1000,
+      successRate: Math.random() * 20 + 80,
+      averageResponseTime: Math.random() * 500 + 100,
+      systemUptime: Math.random() * 720 + 720
+    };
   }
 };


### PR DESCRIPTION
## Summary
- consolidate all demo data into `apiFallbackData.js`
- load fallback data in StatsGrid, SystemManager and InfrastructureManager

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f4111d3e88328975e81dc4e8f84f2