### PR TITLE
Fix admin modal manager alias

### DIFF
--- a/enhanced_csp/frontend/js/pages/admin/admin-modals.js
+++ b/enhanced_csp/frontend/js/pages/admin/admin-modals.js
@@ -673,9 +673,13 @@ function closeModal(modalId) {
 if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', () => {
         window.adminModalManager = new AdminModalManager();
+        // Legacy alias for older markup using window.modalManager
+        window.modalManager = window.adminModalManager;
     });
 } else {
     window.adminModalManager = new AdminModalManager();
+    // Legacy alias for older markup using window.modalManager
+    window.modalManager = window.adminModalManager;
 }
 
 // Export for module systems


### PR DESCRIPTION
## Summary
- ensure old `window.modalManager` references work by aliasing to `adminModalManager`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_685f44da03988328ac77cb11b2efa27d