### PR TITLE
Fix admin portal stylesheet references

### DIFF
--- a/enhanced_csp/frontend/pages/admin.html
+++ b/enhanced_csp/frontend/pages/admin.html
@@ -30,6 +30,7 @@
     <link rel="stylesheet" href="../css/pages/admin/roles.css">
     <link rel="stylesheet" href="../css/pages/admin/backups.css">
     <link rel="stylesheet" href="../css/pages/admin/infrastructure.css">
+    <link rel="stylesheet" href="../css/pages/admin/infrastructureManager.css">
     <link rel="stylesheet" href="../css/pages/admin/systemManager.css">
     <link rel="stylesheet" href="../css/pages/admin/admin-modals.css">
     <script src="../js/pages/admin/alerts_incidents.js" defer></script>


### PR DESCRIPTION
## Summary
- ensure `admin.html` loads the Infrastructure Manager stylesheet

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_685f466efffc8328bac5a14bcf6c056a