### PR TITLE
Fix lazy init of UserManager

### DIFF
--- a/enhanced_csp/frontend/js/pages/admin/userManager.js
+++ b/enhanced_csp/frontend/js/pages/admin/userManager.js
@@ -446,13 +446,16 @@ class UserManager {
 const userManager = new UserManager(window.ApiClient);
 window.userManager = userManager;
 
-/* Auto-init when DOM is ready */
-if (document.readyState !== "loading") {
-  userManager.init();
-} else {
-  document.addEventListener("DOMContentLoaded", () => userManager.init());
+/**
+ * Initializes the global userManager instance on demand.
+ * Called from admin.js when the user management section is first opened.
+ */
+function initializeUserManager() {
+  return userManager.init();
 }
 
+window.initializeUserManager = initializeUserManager;
+
 /* For ES-module / Node unit tests */
-export { UserManager };
+export { UserManager, initializeUserManager };
 export default userManager;

--- a/enhanced_csp/frontend/pages/admin.html
+++ b/enhanced_csp/frontend/pages/admin.html
@@ -321,7 +321,6 @@
     <!-- Page-specific JS -->
     <script src="../js/pages/admin/modalManager.js"></script>
     <script src="../js/pages/admin/admin-modals.js"></script>
-    <script src="../js/pages/admin/userManager.js"></script>
     <script src="../js/pages/admin/systemManager.js"></script>
     <script src="../js/pages/admin/backupsManager.js"></script>
     <script src="../js/pages/admin/infrastructureManager.js"></script>


### PR DESCRIPTION
## Summary
- avoid auto-initializing UserManager
- load UserManager only when user management page opens

## Testing
- `npm test`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_685f503fe8b88328a83f1c164f2a9257