### PR TITLE
Add monitoring stub with feature flag

### DIFF
--- a/enhanced_csp/backend/config/settings.py
+++ b/enhanced_csp/backend/config/settings.py
@@ -268,6 +268,8 @@ class Settings(BaseSettings):
     enable_websockets: bool = Field(default=True)
     enable_authentication: bool = Field(default=True)
     enable_file_upload: bool = Field(default=True)
+    # Monitoring feature flag
+    MONITORING_ENABLED: bool = Field(default=False)
     
     # Configuration sections
     database: DatabaseConfig = Field(default_factory=DatabaseConfig)

--- a/enhanced_csp/main.py
+++ b/enhanced_csp/main.py
@@ -662,10 +662,15 @@ async def initialize_csp_system():
             logger.info("✅ Development tools initialized (fallback mode)")
         
         # 6. Initialize monitoring
-        if MONITORING_AVAILABLE:
-            system_state.monitor = CSPMonitor()
-            await system_state.monitor.start()
+        from backend.config.settings import settings
+        if settings.MONITORING_ENABLED:
+            from monitoring.csp_monitoring import get_default
+            monitoring_system = get_default()
+            await monitoring_system.initialize()
+            system_state.monitor = monitoring_system
             logger.info("✅ Monitoring system initialized")
+        else:
+            logger.info("ℹ️  Monitoring disabled by config")
         
         logger.info("✅ Enhanced CSP System initialization completed")
         

--- a/monitoring/csp_monitoring.py
+++ b/monitoring/csp_monitoring.py
@@ -1,0 +1,23 @@
+class MonitoringSystem:
+    """Placeholder monitoring system."""
+
+    def __init__(self, config: dict | None = None):
+        self.config = config or {}
+        self.is_active = False
+
+    async def initialize(self):
+        """Initialize monitoring hooks."""
+        # TODO: integrate real metrics collection here
+        self.is_active = True
+
+    async def shutdown(self):
+        """Shutdown monitoring system."""
+        self.is_active = False
+
+
+_default_monitor = MonitoringSystem()
+
+
+def get_default() -> MonitoringSystem:
+    """Return a singleton monitoring system instance."""
+    return _default_monitor

--- a/tests/test_monitoring_stub.py
+++ b/tests/test_monitoring_stub.py
@@ -1,0 +1,27 @@
+import importlib
+import os
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_initialize_sets_active():
+    from monitoring.csp_monitoring import get_default
+
+    monitor = get_default()
+    await monitor.initialize()
+    assert monitor.is_active
+    await monitor.shutdown()
+    assert not monitor.is_active
+
+
+def test_import_works_with_and_without_flag(monkeypatch):
+    monkeypatch.delenv("MONITORING_ENABLED", raising=False)
+    mod = importlib.reload(importlib.import_module("enhanced_csp.backend.config.settings"))
+    assert mod.settings.MONITORING_ENABLED is False
+    from monitoring import csp_monitoring  # should import without error
+
+    monkeypatch.setenv("MONITORING_ENABLED", "true")
+    mod = importlib.reload(importlib.import_module("enhanced_csp.backend.config.settings"))
+    assert mod.settings.MONITORING_ENABLED is True
+    from monitoring import csp_monitoring as _  # reimport to ensure still works
+


### PR DESCRIPTION
## Summary
- add minimal monitoring subsystem stub
- expose `MONITORING_ENABLED` in settings
- start monitoring based on the flag
- add tests for the monitoring stub

## Testing
- `pytest tests/test_monitoring_stub.py -q`
- `pytest -q` *(fails: ImportError: cannot import name 'NetworkConfig')*

------
https://chatgpt.com/codex/tasks/task_e_68633d09c2a08328a252da6d2ad2dccd