### PR TITLE
Fix Loki setup script insertion

### DIFF
--- a/enhanced_csp/monitoring/docker-compose.monitoring.yml
+++ b/enhanced_csp/monitoring/docker-compose.monitoring.yml
@@ -95,10 +95,6 @@ services:
       - scripts_csp-network
     restart: unless-stopped
 
-networks:
-  scripts_csp-network:
-    external: true
-
   loki:
     image: grafana/loki:latest
     container_name: csp_loki
@@ -133,6 +129,10 @@ networks:
     restart: unless-stopped
     depends_on:
       - loki
+
+networks:
+  scripts_csp-network:
+    external: true
 
 volumes:
   loki_data:

--- a/enhanced_csp/setup-loki.sh
+++ b/enhanced_csp/setup-loki.sh
@@ -46,8 +46,8 @@ echo "Updating docker-compose file..."
 if ! grep -q "loki:" monitoring/docker-compose.monitoring.yml 2>/dev/null; then
     echo "Adding Loki services to docker-compose.monitoring.yml..."
     
-    # Add Loki services before the volumes section
-    sed -i '/^volumes:/i \
+    # Add Loki services before the networks section
+    sed -i '/^networks:/i \
   loki:\
     image: grafana/loki:latest\
     container_name: csp_loki\


### PR DESCRIPTION
## Summary
- correct the insertion location for Loki services in `setup-loki.sh`
- move Loki and Promtail services into the `services` section of `docker-compose.monitoring.yml`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*


------
https://chatgpt.com/codex/tasks/task_e_6863767e617c8328aa8a0f588260d2a1