### PR TITLE
Add GitHub CI/CD workflows

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,43 @@
+name: Build and Test
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: >-
+            pip-${{ runner.os }}-${{ hashFiles('enhanced_csp/requirements.txt') }}
+          restore-keys: |
+            pip-${{ runner.os }}-
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r enhanced_csp/requirements.txt
+          pip install ruff mypy black pytest pytest-cov
+      - name: Run Ruff
+        run: ruff enhanced_csp
+      - name: Run MyPy
+        run: mypy enhanced_csp
+      - name: Check formatting
+        run: black --check enhanced_csp
+      - name: Run tests
+        run: pytest --cov=enhanced_csp --cov-report=xml
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml
+          path: coverage.xml
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -1,0 +1,26 @@
+name: Run DB Migrations
+
+on:
+  workflow_dispatch:
+
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-lock.txt
+          pip install alembic
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: Run migrations
+        run: alembic upgrade head
+

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,64 @@
+name: Deploy Production
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  staging:
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.8.x
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: Terraform Init
+        run: terraform -chdir=terraform init
+      - name: Terraform Format
+        run: terraform -chdir=terraform fmt -check
+      - name: Terraform Validate
+        run: terraform -chdir=terraform validate
+      - name: Terraform Apply Staging
+        run: terraform -chdir=terraform apply -auto-approve
+
+  production:
+    runs-on: ubuntu-latest
+    needs: staging
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.8.x
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: Terraform Init
+        run: terraform -chdir=terraform init
+      - name: Terraform Format
+        run: terraform -chdir=terraform fmt -check
+      - name: Terraform Validate
+        run: terraform -chdir=terraform validate
+      - name: Terraform Apply Production
+        id: apply
+        run: terraform -chdir=terraform apply -auto-approve
+      - name: Rollback on failure
+        if: failure()
+        run: terraform -chdir=terraform destroy -auto-approve
+      - name: Slack Notification
+        if: always()
+        env:
+          WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+          STATUS: ${{ job.status }}
+        run: |
+          curl -X POST -H 'Content-type: application/json' --data '{"text":"Deploy ${STATUS} for ${{ github.sha }}"}' "$WEBHOOK"
+

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,46 @@
+name: Docker Publish
+
+on:
+  push:
+    branches: ["main"]
+    tags:
+      - 'v1.*'
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - service: backend
+            context: ./enhanced_csp/backend
+            dockerfile: ./enhanced_csp/backend/Dockerfile
+          - service: frontend
+            context: ./enhanced_csp/frontend
+            dockerfile: ./enhanced_csp/frontend/Dockerfile
+          - service: exporters
+            context: ./monitoring
+            dockerfile: ./monitoring/Dockerfile
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ghcr.io/${{ github.repository_owner }}/${{ matrix.service }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # csp-agent-network
 
+[![Tests](https://github.com/stevross-git/enhanced_csp/actions/workflows/build-test.yml/badge.svg)](https://github.com/stevross-git/enhanced_csp/actions/workflows/build-test.yml)
+[![Docker Build](https://github.com/stevross-git/enhanced_csp/actions/workflows/docker-publish.yml/badge.svg)](https://github.com/stevross-git/enhanced_csp/actions/workflows/docker-publish.yml)
+[![Prod Deploy](https://github.com/stevross-git/enhanced_csp/actions/workflows/deploy-production.yml/badge.svg)](https://github.com/stevross-git/enhanced_csp/actions/workflows/deploy-production.yml)
+
 ## Migration Map
 Old Symbol | New Module
 --- | ---
@@ -47,3 +51,17 @@ docker compose -f deploy/docker/docker-compose.yaml up -d
 ```bash
 helm install enhanced-csp deploy/helm/enhanced-csp
 ```
+
+## Secrets and Variables
+
+Add the following secrets in **Settings → Secrets** for CI/CD workflows:
+
+| Name | Purpose |
+| ---- | ------- |
+| `AWS_ACCESS_KEY_ID` | AWS access key for automation |
+| `AWS_SECRET_ACCESS_KEY` | AWS secret key |
+| `AWS_REGION` | Default AWS region |
+| `TF_BACKEND_BUCKET` | S3 bucket for Terraform state |
+| `TF_DYNAMODB_TABLE` | DynamoDB table for state locking |
+| `GITHUB_TOKEN` | Automatically provided GitHub token |
+


### PR DESCRIPTION
## Summary
- add build-test workflow for linting, typing and tests
- publish multi-arch docker images on pushes to `main`
- deploy via terraform on release or manual dispatch
- example database migration workflow
- document required secrets and add CI badges
- bump action versions in legacy `ci.yml`

## Testing
- `actionlint -color`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic_settings')*

------
https://chatgpt.com/codex/tasks/task_e_6863783b3aa8832899bdf26485f58d4b