### PR TITLE
Fix metrics method for EnhancedCSPNetwork

### DIFF
--- a/enhanced_csp/network/core/node.py
+++ b/enhanced_csp/network/core/node.py
@@ -646,3 +646,17 @@ class EnhancedCSPNetwork:
     def get_node(self, name: str = "default") -> Optional[NetworkNode]:
         """Get a network node by name."""
         return self.nodes.get(name)
+
+    async def metrics(self) -> Dict[str, Any]:
+        """Return network metrics including per-node details."""
+        # Base metrics for the overall network
+        metrics_snapshot = self.metrics.copy()
+
+        # Include metrics for each managed node
+        node_metrics = {}
+        for name, node in self.nodes.items():
+            # Each NetworkNode stores metrics as a dictionary
+            node_metrics[name] = getattr(node, "metrics", {}).copy()
+
+        metrics_snapshot["nodes"] = node_metrics
+        return metrics_snapshot


### PR DESCRIPTION
## Summary
- implement `metrics` coroutine on `EnhancedCSPNetwork`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'uvicorn')*

------
https://chatgpt.com/codex/tasks/task_e_686c3865e6d08328bb3fa4bec8933a3e