### PR TITLE
Document network module

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,10 @@ For a deeper look at the backend architecture see
 The mapping of frontend services to backend routes is documented in
 [`docs/frontend_backend_api_mapping.md`](docs/frontend_backend_api_mapping.md).
 
+Detailed setup instructions for the FastAPI backend live in
+[`enhanced_csp/backend/README.md`](enhanced_csp/backend/README.md).
+Frontend configuration and development instructions are in [`enhanced_csp/frontend/README.md`](enhanced_csp/frontend/README.md).
+
+Documentation on the database schemas is available in [docs/database_schema_overview.md](docs/database_schema_overview.md).
+The peer-to-peer networking layer is documented in
+[`enhanced_csp/network/README.md`](enhanced_csp/network/README.md).

--- a/docs/database_schema_overview.md
+++ b/docs/database_schema_overview.md
@@ -1,0 +1,62 @@
+# Database and Schema Overview
+
+This repository uses **PostgreSQL** as the main data store. Two closely related database schemas are employed:
+
+1. **Application Database** – models defined with SQLAlchemy under `enhanced_csp/backend`.
+2. **Network Schema** – an advanced schema for networking metrics located in `enhanced_csp/network`.
+
+## Application Database
+
+The application backend relies on asynchronous SQLAlchemy. Connections are managed via `backend/database/connection.py`. Table definitions live in `backend/models/database_models.py` and are automatically created at startup by the `create_tables()` function.
+
+Key tables include:
+
+- `users` and `local_users` – authentication records.
+- `designs`, `design_nodes`, `design_connections` – Visual Designer entities.
+- `execution_sessions` and `execution_metrics` – execution tracking.
+- `component_types` – registry of available component implementations.
+- `audit_logs`, `system_config`, `notifications`, and `licenses` – system management tables.
+
+A separate `monitoring` schema stores generic metrics via the `MonitoringMetric` model.
+
+## Network Schema
+
+The networking subsystem uses a dedicated `network` schema. The full SQL definition is contained in [`enhanced_csp/network-database-schema.txt`](../enhanced_csp/network-database-schema.txt).  A setup script [`enhanced_csp/setup-network-database.sh`](../enhanced_csp/setup-network-database.sh) creates the schema and helper functions.
+
+Important tables and views:
+
+- **Core tables** – `nodes`, `mesh_topologies`, `mesh_links` describe the mesh topology.
+- **Routing** – `routing_entries` with associated `routing_metrics` maintain BATMAN-style routes.
+- **Connection pooling** – `connection_pools` and `connections` manage socket pools.
+- **Optimization and compression** – `optimization_params`, `compression_stats`.
+- **Batching metrics** – `batch_configs`, `batch_metrics`.
+- **Telemetry** – `metrics`, `events`, and `performance_snapshots` with views such as `realtime_status`.
+- **Service discovery** – `dns_cache` and `service_registry`.
+- **History** – `topology_optimizations` for tracking optimization runs.
+
+Triggers in the schema update timestamps and maintain best routes. Monthly partitions are created for the `metrics` table.
+
+## Initialization
+
+To create the application tables and populate default component types run:
+
+```bash
+python -m enhanced_csp.backend.main  # during startup
+```
+
+For the network schema execute:
+
+```bash
+bash enhanced_csp/setup-network-database.sh
+```
+
+Both processes expect a PostgreSQL instance configured via environment variables (e.g., `DATABASE_URL` or `NETWORK_DATABASE_URL`).
+
+## Directory Layout
+
+- `enhanced_csp/backend/database` – engine configuration and utilities.
+- `enhanced_csp/backend/models` – ORM models for the API.
+- `enhanced_csp/network/database_models.py` – ORM models mirroring the network schema.
+- `enhanced_csp/network-database-schema.txt` – declarative SQL schema.
+
+These files collectively define and manage the database layer for the project.

--- a/enhanced_csp/backend/README.md
+++ b/enhanced_csp/backend/README.md
@@ -1,0 +1,34 @@
+# Enhanced CSP Backend
+
+This directory contains the FastAPI backend that powers the CSP Visual Designer and monitoring services. It exposes over 70 API endpoints and includes a background execution engine and metrics collection tools.
+
+## Requirements
+- Python 3.8+
+- PostgreSQL for persistent storage
+- Redis for caching and monitoring queues
+
+## Installation
+Install Python packages using the locked requirements file:
+```bash
+pip install -r requirements-lock.txt
+```
+
+A running PostgreSQL instance is expected. Configure the connection using the `DATABASE_URL` environment variable. The optional network schema can be configured with `NETWORK_DATABASE_URL`.
+
+## Running the Server
+Start the API server in development mode with:
+```bash
+uvicorn enhanced_csp.backend.main:app --reload
+```
+This will automatically create the required tables by invoking `create_tables()` at startup.
+
+## Tests
+Execute the backend test suite with:
+```bash
+pytest -vv
+```
+
+## Additional Documentation
+- [Backend architecture overview](../../docs/backend_overview.md)
+- [Database and schema details](../../docs/database_schema_overview.md)
+- [API review report](backend_api_review.md)

--- a/enhanced_csp/frontend/README.md
+++ b/enhanced_csp/frontend/README.md
@@ -1,44 +1,57 @@
-# 🚀 Enhanced CSP System - Frontend Setup
+# Enhanced CSP Frontend
 
-## Quick Start
+This directory contains the single-page application (SPA) used to administer the Enhanced CSP system.  It integrates with Azure Active Directory for authentication and communicates with the FastAPI backend.
 
-1. **Configure Azure AD** (if not done already):
-   - Follow the reconfiguration guide
-   - Set up as Single-page application (SPA)
-   - Add redirect URIs for localhost:3000
+## Requirements
+- Node.js 18+ and npm
+- Python 3.8+ (for the bundled development server)
 
-2. **Start the test server**:
-   ```bash
-   cd /home/mate/PAIN/csp-agent-network/csp-agent-network-1/enhanced_csp/frontend
-   python3 test-server.py
-   ```
+## Installation
+Install the JavaScript dependencies and prepare environment variables:
 
-3. **Access the application**:
-   - Login: http://localhost:3000/pages/login.html
-   - Dashboard: http://localhost:3000/csp_admin_portal.html
+```bash
+cd enhanced_csp/frontend
+npm install
+cp .env.example .env  # then edit values as needed
+```
 
-## Configuration
+## Running the Development Server
+Launch the local server which serves the static files and proxies API requests:
 
+```bash
+npm start
+```
 
+By default it listens on `http://localhost:3000`. Useful pages include:
 
-## File Structure
+- `http://localhost:3000/pages/login.html` – login screen
+- `http://localhost:3000/csp_admin_portal.html` – main dashboard
+
+The server exposes `/health` and `/config.js` endpoints for basic status checks.
+
+## Testing
+End‑to‑end tests reside in the `cypress/` directory and can be started with:
+
+```bash
+npx cypress open
+```
+
+## Directory Overview
 
 ```
 frontend/
-├── config/
-│   └── azureConfig.js       # Azure AD configuration
-├── services/
-│   └── authService.js       # Authentication service
-├── pages/
-│   └── login.html          # Login page with Azure AD
-├── test-server.py          # Development server
-├── package.json            # Dependencies
-└── README.md              # This file
+├── components/          # React UI components
+├── config/              # Authentication and role definitions
+├── css/                 # Stylesheets
+├── cypress/             # Cypress tests
+├── hooks/               # Custom React hooks
+├── js/                  # Core logic and page scripts
+├── middleware/          # Express-style middleware
+├── pages/               # HTML entry points
+├── services/            # API wrappers and session handling
+├── stores/              # Zustand state stores
+├── test-server.py       # Development server
+└── package.json
 ```
 
-## Next Steps
-
-1. Test Azure AD authentication
-2. Create user groups in Azure AD
-3. Implement role-based access control
-4. Deploy to production
+For backend setup details see [`../backend/README.md`](../backend/README.md).

--- a/enhanced_csp/network/README.md
+++ b/enhanced_csp/network/README.md
@@ -1,0 +1,48 @@
+# Enhanced CSP Network
+
+This module implements the peer‑to‑peer networking layer used by the Enhanced CSP platform. It provides mesh routing, peer discovery, connection pooling, and metrics collection. The network stack can operate independently or alongside the FastAPI backend.
+
+## Requirements
+- Python 3.8+
+- Optional: `aiohttp` for the metrics endpoint and dashboard
+
+## Installation
+Install the Python dependencies from the root of the repository:
+
+```bash
+pip install -r requirements-lock.txt
+```
+
+If you plan to use the network database schema, ensure PostgreSQL is available and set the `NETWORK_DATABASE_URL` environment variable. The schema can be initialized with `enhanced_csp/setup-network-database.sh`.
+
+## Running a Network Node
+Start a local node using the provided entry script:
+
+```bash
+python -m enhanced_csp.network.main --genesis
+```
+
+Additional options are available via `--help`. The node supports peer discovery, NAT traversal, and can expose a simple HTTP dashboard when `aiohttp` is installed.
+
+## Tests
+Execute the network tests only:
+
+```bash
+pytest enhanced_csp/network/tests -vv
+```
+
+## Directory Overview
+```
+network/
+├── core/          # Node primitives and type definitions
+├── dns/           # Lightweight DNS overlay for service discovery
+├── p2p/           # DHT, NAT traversal and transport modules
+├── mesh/          # Mesh topology and routing algorithms
+├── routing/       # Adaptive and multipath routing engines
+├── examples/      # Example applications using the network stack
+├── dashboard/     # Optional real‑time monitoring dashboard
+├── database_models.py  # SQLAlchemy models for the network schema
+└── tests/         # Unit and integration tests
+```
+
+Further details on the database schemas can be found in [../docs/database_schema_overview.md](../../docs/database_schema_overview.md).


### PR DESCRIPTION
## Summary
- add a README for the `enhanced_csp/network` module with setup and usage
- link the network documentation from the main README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68718f6746a8832899f4575fa5288313